### PR TITLE
fix(allowEmpty): return empty string also when value is empty string

### DIFF
--- a/src/__tests__/createNumberMask.test.js
+++ b/src/__tests__/createNumberMask.test.js
@@ -139,6 +139,16 @@ describe('Number mask', () => {
     expect(mask.format()).toBe('');
   });
 
+  it('should be formatting as empty string when the value on the store is empty string and allowEmpty is true', () => {
+    const mask = createNumberMask({
+      prefix: 'p',
+      suffix: 's',
+      allowEmpty: true,
+    });
+
+    expect(mask.format('')).toBe('');
+  });
+
   it('should update the stored value correctly', () => {
     const prefix = 'prefix 1@,.';
     const suffix = '1@,. suffix';

--- a/src/createNumberMask.js
+++ b/src/createNumberMask.js
@@ -23,7 +23,7 @@ export default options => {
 
   const format = storeValue => {
     let number = storeValue;
-    if (number === undefined) {
+    if (number === undefined || number === '') {
       if (allowEmpty) {
         return '';
       }


### PR DESCRIPTION
In the current version if we have initialized the form with the data we were unable to delete the value even with the `allowEmpty` option set to true. It is happening because `value` passed to the `format` method is an empty string instead of undefined.